### PR TITLE
Fix: Resolve failing tests for Character and Monster imports

### DIFF
--- a/app/Filament/Resources/CharacterResource/Pages/CreateCharacter.php
+++ b/app/Filament/Resources/CharacterResource/Pages/CreateCharacter.php
@@ -10,6 +10,8 @@ class CreateCharacter extends CreateRecord
 {
     protected static string $resource = CharacterResource::class;
 
+    public $character_json_upload = null;
+
     protected function mutateFormDataBeforeCreate(array $data): array
     {
         $data['user_id'] = auth()->id(); // Assign current user's ID

--- a/tests/Feature/Filament/MonsterImportActionTest.php
+++ b/tests/Feature/Filament/MonsterImportActionTest.php
@@ -21,17 +21,16 @@ class MonsterImportActionTest extends TestCase
         parent::setUp();
         Storage::fake('livewire-tmp'); // Fake the disk Livewire uses for temporary uploads
         // Create a user and act as that user.
-        // Ensure the user model has 'is_admin' or adapt to your auth system.
-        $user = User::factory()->create([
-            // Add 'is_admin' => true if your User model/factory supports it and it's needed for access.
-            // e.g., 'is_admin' => true,
-        ]);
+        $user = User::factory()->create();
         $this->actingAs($user);
+        // Set the current panel for the test
+        \Filament\Facades\Filament::setCurrentPanel(\Filament\Facades\Filament::getPanel('app'));
     }
 
     public function test_monster_list_page_contains_bulk_import_action_and_modal()
     {
-        $this->get(MonsterResource::getUrl('index'))
+        // Pass the panel to getUrl to be explicit
+        $this->get(MonsterResource::getUrl('index', panel: 'app'))
             ->assertSuccessful()
             ->assertSee('Bulk Import Monsters'); // Check if the button text is present
     }


### PR DESCRIPTION
- Added missing `character_json_upload` property to `CreateCharacter.php` to resolve PropertyNotFoundException in CharacterResourceTest.
- Corrected Filament panel context in `MonsterImportActionTest.php` to ensure the 'Bulk Import Monsters' action is found during testing.