### PR TITLE
Fix: Prevent reordering of combatants on run encounter page

### DIFF
--- a/app/Filament/Resources/EncounterResource/Pages/RunEncounter.php
+++ b/app/Filament/Resources/EncounterResource/Pages/RunEncounter.php
@@ -250,25 +250,7 @@ class RunEncounter extends ViewRecord
 										 ->sortBy('order')
 										 ->values();
 
-		$currentTurnOrder = $this->record->current_turn;
-
-		if ($currentTurnOrder !== null && $currentTurnOrder > 0 && !$allCombatants->isEmpty()) {
-			$currentIndex = $allCombatants->search(function ($combatant) use ($currentTurnOrder) {
-				return $combatant['order'] == $currentTurnOrder;
-			});
-
-			if ($currentIndex !== false) {
-				$currentCombatant = $allCombatants->pull($currentIndex);
-				$reorderedCombatants = collect([$currentCombatant])->merge($allCombatants);
-				$this->combatantsForView = $reorderedCombatants->values()->all();
-			} else {
-				// Current turn points to a non-existent combatant, fall back to default order
-				$this->combatantsForView = $allCombatants->all();
-			}
-		} else {
-			// Encounter not started or no combatants, use default order
-			$this->combatantsForView = $allCombatants->all();
-		}
+		$this->combatantsForView = $allCombatants->all();
 	}
 
     public function showMonsterModal(int $monsterInstanceId): void


### PR DESCRIPTION
The combatant list on the run encounter page no longer reorders to place the current combatant at the top. The list remains static, sorted by initiative, and the turn indicator moves through the list.